### PR TITLE
Add feature - allow extra property on main config

### DIFF
--- a/src/MailgunAdapter.js
+++ b/src/MailgunAdapter.js
@@ -124,6 +124,7 @@ class MailgunAdapter extends MailAdapter {
         let { message, templateVars } = args;
         let pathPlainText = template.pathPlainText;
         let pathHtml = template.pathHtml;
+        let extra = template.extra || {};
         let cachedTemplate = this.cache[templateName] = this.cache[templateName] || {};
 
         // Load plain-text version
@@ -145,6 +146,9 @@ class MailgunAdapter extends MailAdapter {
             // Add processed HTML to the message object
             message.html = Mustache.render(cachedTemplate['html'], templateVars);
         }
+
+        // Append any `extra` properties from config
+        message = Object.assign(message, extra || {});
 
         // Initialize mailcomposer with message
         const composer = this.mailcomposer(message);


### PR DESCRIPTION
Please review my request to allow the "extra" property in the main config file. This would allow for attachments and replyTo headers in the transactional emails ("email-verify" and "change-password"), which is currently not possible.

Example config:

```
        customEmail: {
            subject: 'Test custom email template',
            pathPlainText: path.join(__dirname, 'email-templates/custom_email.txt'),
            pathHtml: path.join(__dirname, 'email-templates/custom_email.html'),
            extra: {
                attachments: [
                    {
                        cid: '1px-trans-image',
                        encoding: 'base64',
                        filename: 'trans.gif',
                        path: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP',
                    }
                ],
                replyTo: 'reply@test.com',
            },
        },
```

I've also included tests.